### PR TITLE
update rawspeed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+before_script:
+  - sudo apt-get install -y libfftw3-dev libgconf2-dev libgtk2.0-dev libjpeg-dev libtiff4-dev liblcms2-dev libcurl4-gnutls-dev libexiv2-dev liblcms1-dev libflickcurl-dev libsqlite3-dev libgphoto2-2-dev autoconf automake liblensfun-dev libosmgpsmap-dev libsoup2.4-dev
+  - git clone https://github.com/jbuchbinder/rawspeed.git
+  - ( cd plugins/load-rawspeed ; ln -s ../../rawspeed/RawSpeed rawspeed ; ln -s ../../rawspeed/data . )
+script:
+  - ./autogen.sh
+  - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ addons:
      - libexiv2-dev
      - libflickcurl-dev
      - libsqlite3-dev
-#     - libgphoto2-dev
-     - libgphoto2-dev-doc
-     - libgphoto2-2-dev
+     - libgphoto2-dev
+#     - libgphoto2-dev-doc
+#     - libgphoto2-2-dev
      - autoconf
      - automake
      - liblensfun-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,48 @@
+sudo: false
+dist: trusty
 language: c
+addons:
+  apt:
+    packages:
+     - libfftw3-dev
+     - libgconf2-dev
+     - libgtk-3-dev
+     - libgtk-3-common
+     - libgtk-3-0
+     - libjpeg-dev
+     - libtiff4-dev
+     - liblcms2-dev
+     - libcurl4-gnutls-dev
+     - libexiv2-dev
+     - libflickcurl-dev
+     - libsqlite3-dev
+#     - libgphoto2-dev
+     - libgphoto2-dev-doc
+     - libgphoto2-2-dev
+     - autoconf
+     - automake
+     - liblensfun-dev
+#     - libosmgpsmap-dev
+     - libsoup2.4-dev
+
+before_install:
+#  - apt-get update -qq
+#  - sudo apt-get install -y libfftw3-dev libgconf2-dev libgtk-3-dev libjpeg-dev libtiff4-dev liblcms2-dev libcurl4-gnutls-dev libexiv2-dev libflickcurl-dev libsqlite3-dev libgphoto2-2-dev autoconf automake liblensfun-dev liblensfun-data libsoup2.4-dev
+#  - git clone https://github.com/klauspost/rawspeed.git
+#  - cd rawspeed
+#  - git checkout 4ea46dd
+#  - cd ..
+#  - rmdir plugins/load-rawspeed/rawspeed
+#  - ( cd plugins/load-rawspeed ; ln -s ../../rawspeed/RawSpeed rawspeed ; ln -s ../../rawspeed/data . )
+
 before_script:
-  - sudo apt-get install -y libfftw3-dev libgconf2-dev libgtk2.0-dev libjpeg-dev libtiff4-dev liblcms2-dev libcurl4-gnutls-dev libexiv2-dev liblcms1-dev libflickcurl-dev libsqlite3-dev libgphoto2-2-dev autoconf automake liblensfun-dev libosmgpsmap-dev libsoup2.4-dev
-  - git clone https://github.com/jbuchbinder/rawspeed.git
-  - ( cd plugins/load-rawspeed ; ln -s ../../rawspeed/RawSpeed rawspeed ; ln -s ../../rawspeed/data . )
+#  - mkdir m4
+#  - aclocal
+#  - autoreconf -i
+#  - echo "Running glib-gettextize...  Ignore non-fatal messages."
+#  - glib-gettextize --copy
+   - ./autogen.sh --no-configure
+
 script:
-  - ./autogen.sh
+  - ./configure --program-prefix= --disable-dependency-tracking --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --datadir=/usr/share --includedir=/usr/include --libdir=/usr/lib64 --libexecdir=/usr/libexec --localstatedir=/var --sharedstatedir=/var/lib --mandir=/usr/share/man --infodir=/usr/share/info --disable-static --enable-experimental --enable-maintainer-mode
   - make all

--- a/autogen.sh
+++ b/autogen.sh
@@ -105,6 +105,10 @@ autoreconf -i
 echo "Running glib-gettextize...  Ignore non-fatal messages."
 glib-gettextize --copy
 
+if ( echo "$@" | grep -q -e "--no-configure" ); then
+  NOCONFIGURE=1
+fi
+
 conf_flags="--enable-maintainer-mode"
 
 if test x$NOCONFIGURE = x; then

--- a/autogen.sh
+++ b/autogen.sh
@@ -67,7 +67,7 @@ fi
   (grep "sed.*POTFILES" $srcdir/configure.ac) > /dev/null || \
   (glib-gettextize --version) < /dev/null > /dev/null 2>&1 || {
     echo
-    echo "**Error**: You must have \`glib' installed."
+    echo "**Error**: You must have \`glib-gettextize' installed."
     echo "You can get it from: ftp://ftp.gtk.org/pub/gtk"
     DIE=1
   }

--- a/autogen.sh
+++ b/autogen.sh
@@ -99,68 +99,11 @@ fi
 git submodule init
 git submodule update
 
-if test -z "$*"; then
-  echo "**Warning**: I am going to run \`configure' with no arguments."
-  echo "If you wish to pass any to it, please specify them on the"
-  echo \`$0\'" command line."
-  echo
-fi
-
-case $CC in
-xlc )
-  am_opt=--include-deps;;
-esac
-
-for coin in `find $srcdir -name configure.ac -print`
-do 
-  dr=`dirname $coin`
-  if test -f $dr/NO-AUTO-GEN; then
-    echo skipping $dr -- flagged as no auto-gen
-  else
-    echo processing $dr
-    ( cd $dr
-
-      aclocalinclude="$ACLOCAL_FLAGS"
-
-      if grep "^AM_GLIB_GNU_GETTEXT" configure.ac >/dev/null; then
-	echo "Creating $dr/aclocal.m4 ..."
-	test -r $dr/aclocal.m4 || touch $dr/aclocal.m4
-	echo "Running glib-gettextize...  Ignore non-fatal messages."
-	echo "no" | glib-gettextize --force --copy
-	echo "Making $dr/aclocal.m4 writable ..."
-	test -r $dr/aclocal.m4 && chmod u+w $dr/aclocal.m4
-      fi
-      if grep "^AC_PROG_INTLTOOL" configure.ac >/dev/null; then
-        echo "Running intltoolize..."
-	intltoolize --copy --force --automake
-      fi
-      if grep "^AM_PROG_XML_I18N_TOOLS" configure.ac >/dev/null; then
-        echo "Running xml-i18n-toolize..."
-	xml-i18n-toolize --copy --force --automake
-      fi
-      if grep "^AM_PROG_LIBTOOL" configure.ac >/dev/null; then
-	if test -z "$NO_LIBTOOLIZE" ; then 
-	  echo "Running libtoolize..."
-	  libtoolize --force --copy
-	fi
-      fi
-      echo "Running aclocal $aclocalinclude ..."
-      aclocal $aclocalinclude
-      if grep "^AM_CONFIG_HEADER" configure.ac >/dev/null; then
-	echo "Running autoheader..."
-	autoheader
-      fi
-      echo "Running automake --gnu $am_opt ..."
-      automake --add-missing --gnu $am_opt
-      echo "Running autoconf ..."
-      autoconf
-    )
-  fi
-done
-
-if [ -d .svn ] && svn --version >/dev/null 2>&1 ; then
-  LC_ALL=C svn info > .svninfo
-fi
+mkdir m4
+aclocal
+autoreconf -i
+echo "Running glib-gettextize...  Ignore non-fatal messages."
+glib-gettextize --copy
 
 conf_flags="--enable-maintainer-mode"
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,14 +2,13 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_INIT([rawstudio], [2.1])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 AM_MAINTAINER_MODE
 AM_PROG_LIBTOOL
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_ISC_POSIX
 AC_PROG_CC
-AM_PROG_CC_STDC
 AC_PROG_CXX
 AC_HEADER_STDC
 

--- a/librawstudio/rs-image16.h
+++ b/librawstudio/rs-image16.h
@@ -85,7 +85,7 @@ extern RS_IMAGE16 *rs_image16_copy(RS_IMAGE16 *rsi, gboolean copy_pixels);
  * @param y Y coordinate (row)
  * @param extend_edges Tries to extend edges beyond image borders if TRUE
  */
-extern inline gushort *rs_image16_get_pixel(RS_IMAGE16 *image, gint x, gint y, gboolean extend_edges);
+extern gushort *rs_image16_get_pixel(RS_IMAGE16 *image, gint x, gint y, gboolean extend_edges);
 
 extern gchar *rs_image16_get_checksum(RS_IMAGE16 *image);
 

--- a/librawstudio/rs-lens-db-editor.c
+++ b/librawstudio/rs-lens-db-editor.c
@@ -106,6 +106,8 @@ static void lens_set (lens_data *data, const lfLens *lens)
 
 		return;
 	}
+    if (!rs_lens_get_lensfun_model(data->single_lens_data->lens))
+        return;
 
 	GtkTreeSelection *selection = gtk_tree_view_get_selection(data->tree_view);
 	GtkTreeModel *model = NULL;

--- a/plugins/load-png/load-png.c
+++ b/plugins/load-png/load-png.c
@@ -18,6 +18,7 @@
  */
 
 #include <rawstudio.h>
+#include <stdlib.h> /* malloc() */
 #include <math.h> /* pow() */
 #include <png.h>
 #include <setjmp.h>

--- a/plugins/load-rawspeed/.gitignore
+++ b/plugins/load-rawspeed/.gitignore
@@ -1,0 +1,1 @@
+RawSpeed/*.o

--- a/plugins/load-rawspeed/.travis.yml
+++ b/plugins/load-rawspeed/.travis.yml
@@ -1,0 +1,6 @@
+language: c
+before_script:
+  - sudo apt-get install -y libxml2-dev libjpeg-turbo-devel
+script:
+  - ( cd RawSpeed ; for i in *.cpp; do if [ "$i" != "RawSpeed.cpp" ]; then echo "Compiling $i -> ${i//cpp}o"; g++ `xml2-config --cflags --libs` -c $i; fi; done )
+

--- a/plugins/load-rawspeed/Makefile.am
+++ b/plugins/load-rawspeed/Makefile.am
@@ -18,8 +18,10 @@ load_rawspeed_la_LIBADD = @PACKAGE_LIBS@ @LIBJPEG@
 load_rawspeed_la_LDFLAGS = -module -avoid-version
 load_rawspeed_la_SOURCES =  rawstudio-plugin-api.cpp rawstudio-plugin-api.h \
 	rawstudio-plugin.c \
+	rawspeed/RawSpeed/AriDecoder.cpp rawspeed/RawSpeed/AriDecoder.h \
 	rawspeed/RawSpeed/ArwDecoder.cpp rawspeed/RawSpeed/ArwDecoder.h \
 	rawspeed/RawSpeed/BitPumpJPEG.cpp rawspeed/RawSpeed/BitPumpJPEG.h \
+	rawspeed/RawSpeed/BitPumpMSB16.cpp rawspeed/RawSpeed/BitPumpMSB16.h \
 	rawspeed/RawSpeed/BitPumpMSB32.cpp rawspeed/RawSpeed/BitPumpMSB32.h \
 	rawspeed/RawSpeed/BitPumpMSB.cpp rawspeed/RawSpeed/BitPumpMSB.h \
 	rawspeed/RawSpeed/BitPumpPlain.cpp rawspeed/RawSpeed/BitPumpPlain.h \
@@ -30,10 +32,17 @@ load_rawspeed_la_SOURCES =  rawstudio-plugin-api.cpp rawstudio-plugin-api.h \
 	rawspeed/RawSpeed/CameraMetaData.cpp rawspeed/RawSpeed/CameraMetaData.h \
 	rawspeed/RawSpeed/CameraMetadataException.cpp rawspeed/RawSpeed/CameraMetadataException.h \
 	rawspeed/RawSpeed/CameraSensorInfo.cpp rawspeed/RawSpeed/CameraSensorInfo.h \
+	rawspeed/RawSpeed/CiffEntry.cpp rawspeed/RawSpeed/CiffEntry.h \
+	rawspeed/RawSpeed/CiffIFD.cpp rawspeed/RawSpeed/CiffIFD.h \
+	rawspeed/RawSpeed/CiffParser.cpp rawspeed/RawSpeed/CiffParser.h \
+	rawspeed/RawSpeed/CiffParserException.cpp rawspeed/RawSpeed/CiffParserException.h \
+	rawspeed/RawSpeed/CiffTag.h \
 	rawspeed/RawSpeed/ColorFilterArray.cpp rawspeed/RawSpeed/ColorFilterArray.h \
 	rawspeed/RawSpeed/Common.cpp rawspeed/RawSpeed/Common.h \
 	rawspeed/RawSpeed/Cr2Decoder.cpp rawspeed/RawSpeed/Cr2Decoder.h \
+	rawspeed/RawSpeed/CrwDecoder.cpp rawspeed/RawSpeed/CrwDecoder.h \
 	rawspeed/RawSpeed/DcrDecoder.cpp rawspeed/RawSpeed/DcrDecoder.h \
+	rawspeed/RawSpeed/DcsDecoder.cpp rawspeed/RawSpeed/DcsDecoder.h \
 	rawspeed/RawSpeed/DngDecoder.cpp rawspeed/RawSpeed/DngDecoder.h \
 	rawspeed/RawSpeed/DngDecoderSlices.cpp rawspeed/RawSpeed/DngDecoderSlices.h \
 	rawspeed/RawSpeed/DngOpcodes.cpp rawspeed/RawSpeed/DngOpcodes.h \
@@ -50,6 +59,7 @@ load_rawspeed_la_SOURCES =  rawstudio-plugin-api.cpp rawstudio-plugin-api.h \
 	rawspeed/RawSpeed/MefDecoder.cpp rawspeed/RawSpeed/MefDecoder.h \
 	rawspeed/RawSpeed/MosDecoder.cpp rawspeed/RawSpeed/MosDecoder.h \
 	rawspeed/RawSpeed/MrwDecoder.cpp rawspeed/RawSpeed/MrwDecoder.h \
+	rawspeed/RawSpeed/NakedDecoder.cpp rawspeed/RawSpeed/NakedDecoder.h \
 	rawspeed/RawSpeed/NefDecoder.cpp rawspeed/RawSpeed/NefDecoder.h \
 	rawspeed/RawSpeed/NikonDecompressor.cpp rawspeed/RawSpeed/NikonDecompressor.h \
 	rawspeed/RawSpeed/OrfDecoder.cpp rawspeed/RawSpeed/OrfDecoder.h \
@@ -79,13 +89,7 @@ load_rawspeed_la_SOURCES =  rawstudio-plugin-api.cpp rawstudio-plugin-api.h \
 	rawspeed/RawSpeed/TiffTag.h \
 	rawspeed/RawSpeed/X3fDecoder.cpp rawspeed/RawSpeed/X3fDecoder.h \
 	rawspeed/RawSpeed/X3fParser.cpp rawspeed/RawSpeed/X3fParser.h \
-	rawspeed/RawSpeed/pugixml.hpp rawspeed/RawSpeed/pugiconfig.hpp \
-	rawspeed/RawSpeed/CrwDecoder.cpp rawspeed/RawSpeed/CrwDecoder.h \
-	rawspeed/RawSpeed/CiffEntry.cpp rawspeed/RawSpeed/CiffEntry.h \
-	rawspeed/RawSpeed/CiffIFD.cpp rawspeed/RawSpeed/CiffIFD.h \
-	rawspeed/RawSpeed/CiffParser.cpp rawspeed/RawSpeed/CiffParser.h \
-	rawspeed/RawSpeed/CiffParserException.cpp rawspeed/RawSpeed/CiffParserException.h \
-	rawspeed/RawSpeed/CiffTag.h
+	rawspeed/RawSpeed/pugixml.hpp rawspeed/RawSpeed/pugiconfig.hpp
 
 rawspeeddir = $(datadir)/rawspeed
 rawspeed_DATA = rawspeed/data/cameras.xml

--- a/plugins/load-rawspeed/Makefile.am
+++ b/plugins/load-rawspeed/Makefile.am
@@ -76,11 +76,16 @@ load_rawspeed_la_SOURCES =  rawstudio-plugin-api.cpp rawstudio-plugin-api.h \
 	rawspeed/RawSpeed/TiffParser.cpp rawspeed/RawSpeed/TiffParser.h \
 	rawspeed/RawSpeed/TiffParserException.cpp rawspeed/RawSpeed/TiffParserException.h \
 	rawspeed/RawSpeed/TiffParserHeaderless.cpp rawspeed/RawSpeed/TiffParserHeaderless.h \
-	rawspeed/RawSpeed/TiffParserOlympus.cpp rawspeed/RawSpeed/TiffParserOlympus.h \
 	rawspeed/RawSpeed/TiffTag.h \
 	rawspeed/RawSpeed/X3fDecoder.cpp rawspeed/RawSpeed/X3fDecoder.h \
 	rawspeed/RawSpeed/X3fParser.cpp rawspeed/RawSpeed/X3fParser.h \
-	rawspeed/RawSpeed/pugixml.hpp rawspeed/RawSpeed/pugiconfig.hpp
+	rawspeed/RawSpeed/pugixml.hpp rawspeed/RawSpeed/pugiconfig.hpp \
+	rawspeed/RawSpeed/CrwDecoder.cpp rawspeed/RawSpeed/CrwDecoder.h \
+	rawspeed/RawSpeed/CiffEntry.cpp rawspeed/RawSpeed/CiffEntry.h \
+	rawspeed/RawSpeed/CiffIFD.cpp rawspeed/RawSpeed/CiffIFD.h \
+	rawspeed/RawSpeed/CiffParser.cpp rawspeed/RawSpeed/CiffParser.h \
+	rawspeed/RawSpeed/CiffParserException.cpp rawspeed/RawSpeed/CiffParserException.h \
+	rawspeed/RawSpeed/CiffTag.h
 
 rawspeeddir = $(datadir)/rawspeed
 rawspeed_DATA = rawspeed/data/cameras.xml

--- a/src/gtk-interface.c
+++ b/src/gtk-interface.c
@@ -743,7 +743,7 @@ filetype_changed(gpointer active, gpointer user_data)
 	GtkWidget *event = quick->event;
 	GtkWidget *options;
 	RSOutput *output;
-	const gchar *identifier = g_type_name(GPOINTER_TO_INT(active));
+	const gchar *identifier = g_type_name((GType) GPOINTER_TO_SIZE(active));
 
 	quick->output_type = identifier;
 

--- a/src/gtk-interface.c
+++ b/src/gtk-interface.c
@@ -875,8 +875,8 @@ gui_make_preference_quick_export(void)
 	gui_confbox_set_callback(filetype_box, quick, filetype_changed);
 	active = gui_confbox_get_active(filetype_box);
 	if (!active)
-		active = GUINT_TO_POINTER(g_type_from_name("RSJpegfile"));
-	quick->output_type = g_type_name(GPOINTER_TO_INT(active));
+		active = GSIZE_TO_POINTER(g_type_from_name("RSJpegfile"));
+	quick->output_type = g_type_name((GType) GPOINTER_TO_SIZE(active));
 
 	/* Load default from conf, or use RSJpegfile */
 	gui_confbox_load_conf(filetype_box, "RSJpegfile");


### PR DESCRIPTION
I update rawspeed to head commit, after that we just need adjust makefile.am to build all files less rawspeed.cpp (as .travis of rawspeed does) .
After I had to fix 3 crashes of the rawstudio with GTK+ of Fedora 23, luckily found the solution on other app. 
The last fix on rs-lens-db-editor.c:110 , happens when we try deselect lens on one photo that don't have any lens , so before rs-lens-db-editor.c:110, I have to check if it already deselected and return, and it is fixed , rawstudio seems work correctly (with system theme) .

I made builds and test on copr 
https://copr.fedoraproject.org/coprs/sergiomb/rawstudio_2.1/

    dnf copr enable sergiomb/rawstudio_2.1 

I have to put this in rawhide and F23 :-)
