### PR TITLE
Fix a crash when we don't have select lens.

### DIFF
--- a/librawstudio/rs-lens-db-editor.c
+++ b/librawstudio/rs-lens-db-editor.c
@@ -106,6 +106,8 @@ static void lens_set (lens_data *data, const lfLens *lens)
 
 		return;
 	}
+    if (!rs_lens_get_lensfun_model(data->single_lens_data->lens))
+        return;
 
 	GtkTreeSelection *selection = gtk_tree_view_get_selection(data->tree_view);
 	GtkTreeModel *model = NULL;


### PR DESCRIPTION
0  0x00007ffff70fcdae in gtk_tree_view_get_selection
(tree_view=0x7ff0000000000000) at gtktreeview.c:11570
1  0x00007ffff7ba88de in lens_set (data=<optimized out>, lens=0x0) at
rs-lens-db-editor.c:110

With help of gdb, I saw lens_set funtion could be called to deselect a lens
without any select lens, when this happens we return before start clean an empty
data->tree_view and crash in line 110 of rs-lens-db-editor.c, now after this
commit the line was changed to 112.