### PR TITLE
Remove support for Windows and macOS

### DIFF
--- a/librawstudio/rs-icc-profile.c
+++ b/librawstudio/rs-icc-profile.c
@@ -19,11 +19,7 @@
 
 #include <string.h>
 #include <sys/stat.h>
-#ifdef WIN32
-#include <Winsock2.h> /* ntohl() */
-#else
 #include <arpa/inet.h> /* ntohl() */
-#endif
 #include <glib.h>
 #include <glib/gstdio.h>
 #include "rs-icc-profile.h"

--- a/librawstudio/rs-image16.c
+++ b/librawstudio/rs-image16.c
@@ -17,11 +17,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#ifdef WIN32 /* Win32 _aligned_malloc */
-#include <malloc.h>
-#include <stdio.h>
-#endif
-
 #include <rawstudio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -147,13 +142,8 @@ rs_image16_new(const guint width, const guint height, const guint channels, cons
 	rsi->filters = 0;
 
 	/* Allocate actual pixels */
-#ifdef WIN32
-	rsi->pixels = _aligned_malloc(rsi->h*rsi->rowstride * sizeof(gushort), 16); 
-	if (rsi->pixels == NULL)
-#else
 	ret = posix_memalign((void **) &rsi->pixels, 16, rsi->h*rsi->rowstride * sizeof(gushort));
 	if (ret > 0)
-#endif
 	{
 		rsi->pixels = NULL;
 		g_object_unref(rsi);

--- a/librawstudio/rs-macros.h
+++ b/librawstudio/rs-macros.h
@@ -37,17 +37,15 @@
 	type name##_s[(sizex)*(sizey)+(alignment)-1];	\
 	type * name = (type *)(((uintptr_t)name##_s+(alignment - 1))&~((uintptr_t)(alignment)-1))
 
-#ifdef WIN32
-#include <gdk/gdkwin32.h>
-#define GUI_CATCHUP() /* We do not have XFlush or GDK_DISPLAY_XDISPLAY in Win32*/ 
-#else
 #include <gdk/gdkx.h>
+
 #define GUI_CATCHUP() do { \
   GdkDisplay *__gui_catchup_display = gdk_display_get_default (); \
   XFlush (GDK_DISPLAY_XDISPLAY (__gui_catchup_display)); } while (0)
+
 #define GUI_CATCHUP_DISPLAY(X) do { \
   XFlush (GDK_DISPLAY_XDISPLAY (X)); } while (0)
-#endif
+
 #define GTK_CATCHUP() while (gtk_events_pending()) gtk_main_iteration()
 
 #if __GNUC__ >= 3

--- a/librawstudio/rs-utils.c
+++ b/librawstudio/rs-utils.c
@@ -22,9 +22,6 @@
 #include <config.h>
 #include <glib.h>
 #include <glib/gstdio.h>
-#ifdef WIN32
-#include <pthread.h> /* MinGW WIN32 gmtime_r() */
-#endif
 #include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -85,12 +82,8 @@ rs_exiftime_to_unixtime(const gchar *str)
 
 	tm = g_new0(struct tm, 1);
 
-#ifndef WIN32 /* There is no strptime() in time.h in MinGW */
 	if (strptime(str, "%Y:%m:%d %H:%M:%S", tm))
 		timestamp = (GTime) mktime(tm);
-#else
- #warning rs_exiftime_to_unixtime() must be ported to WIN32
-#endif
 
 	g_free(tm);
 
@@ -192,9 +185,6 @@ rs_get_number_of_processor_cores(void)
 			g_io_channel_shutdown(io, FALSE, NULL);
 			g_io_channel_unref(io);
 		}
-#elif defined(_WIN32)
-		/* Use pthread on windows */
-		temp_num = pthread_num_processors_np();
 #else
  #error This needs porting
 #endif
@@ -801,15 +791,7 @@ rs_normalize_path(const gchar *path)
 	gchar *buffer = g_new0(gchar, path_max);
 
 	gchar *ret = NULL;
-#ifdef WIN32
-	int length = GetFullPathName(path, path_max, buffer, NULL);
-	if(length == 0){
-	  g_error("Error normalizing path: %s\n", path);
-	}
-	ret = buffer;
-#else
 	ret = realpath(path, buffer);
-#endif
 
 	if (ret == NULL)
 		g_free(buffer);

--- a/plugins/denoise/fftdenoiser.cpp
+++ b/plugins/denoise/fftdenoiser.cpp
@@ -21,10 +21,6 @@
 #include "complexblock.h"
 #include "fftdenoiseryuv.h"
 
-#ifdef WIN32
-int rs_get_number_of_processor_cores(){return 4;}
-#endif
-
 namespace RawStudio {
 namespace FFTFilter {
 

--- a/plugins/meta-tiff/tiff-meta.c
+++ b/plugins/meta-tiff/tiff-meta.c
@@ -20,11 +20,7 @@
 #include <rawstudio.h>
 #include <gtk/gtk.h>
 #include <math.h>
-#ifdef WIN32
-#include <Winsock2.h> /* ntohl() */
-#else
 #include <arpa/inet.h> /* sony_decrypt(): htonl() */
-#endif
 #include <string.h> /* memcpy() */
 #include <stdlib.h>
 #include "rs-utils.h"

--- a/plugins/output-jpegfile/output-jpegfile.c
+++ b/plugins/output-jpegfile/output-jpegfile.c
@@ -19,10 +19,6 @@
 
 #include "config.h"
 #include <rawstudio.h>
-#ifdef WIN32
-#define HAVE_BOOLEAN
-#define _BASETSD_H_
-#endif
 #include <jpeglib.h>
 #include <gettext.h>
 

--- a/src/filename.c
+++ b/src/filename.c
@@ -19,9 +19,6 @@
 
 #include <glib.h>
 #include <glib/gstdio.h>
-#ifdef WIN32
-#include <pthread.h> /* MinGW WIN32 gmtime_r() */
-#endif
 #include <gtk/gtk.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/gtk-helper.c
+++ b/src/gtk-helper.c
@@ -21,9 +21,7 @@
 #include <glib/gstdio.h>
 #include <gtk/gtk.h>
 #include <config.h>
-#ifndef WIN32
 #include <gconf/gconf-client.h>
-#endif
 #include "application.h"
 #include "conf_interface.h"
 #include "gtk-interface.h"
@@ -692,15 +690,13 @@ gui_label_new_with_mouseover(const gchar *normal_text, const gchar *hover_text)
 void
 gui_box_toggle_callback(GtkExpander *expander, gchar *key)
 {
-#ifndef WIN32
 	GConfClient *client = gconf_client_get_default();
 	gboolean expanded = gtk_expander_get_expanded(expander);
 
 	/* Save state to gconf */
 	gconf_client_set_bool(client, key, expanded, NULL);
-#endif
 }
-#ifndef WIN32
+
 void
 gui_box_notify(GConfClient *client, guint cnxn_id, GConfEntry *entry, gpointer user_data)
 {
@@ -712,7 +708,6 @@ gui_box_notify(GConfClient *client, guint cnxn_id, GConfEntry *entry, gpointer u
 		gtk_expander_set_expanded(expander, expanded);
 	}
 }
-#endif
 
 GtkWidget *
 gui_box(const gchar *title, GtkWidget *in, gchar *key, gboolean default_expanded)
@@ -726,12 +721,10 @@ gui_box(const gchar *title, GtkWidget *in, gchar *key, gboolean default_expanded
 
 	if (key)
 	{
-#ifndef WIN32
 		GConfClient *client = gconf_client_get_default();
 		gchar *name = g_build_filename("/apps", PACKAGE, key, NULL);
 		g_signal_connect_after(expander, "activate", G_CALLBACK(gui_box_toggle_callback), name);
 		gconf_client_notify_add(client, name, gui_box_notify, expander, NULL, NULL);
-#endif
 	}
 	gtk_expander_set_expanded(GTK_EXPANDER(expander), expanded);
 
@@ -751,7 +744,7 @@ rs_get_display_profile(GtkWidget *widget)
 	/* Mainly from UFraw */
 	guint8 *buffer = NULL;
 	gint buffer_size = 0;
-#if defined GDK_WINDOWING_X11
+
 	GdkScreen *screen = gtk_widget_get_screen(widget);
 	if (screen == NULL)
 		screen = gdk_screen_get_default();
@@ -769,47 +762,6 @@ rs_get_display_profile(GtkWidget *widget)
 		0, 64 * 1024 * 1024, FALSE,
 		&type, &format, &buffer_size, &buffer);
 	g_free(atom_name);
-
-#elif defined GDK_WINDOWING_QUARTZ
-	GdkScreen *screen = gtk_widget_get_screen(widget);
-	if (screen == NULL)
-		screen = gdk_screen_get_default();
-	int monitor = gdk_screen_get_monitor_at_window(screen, widget->window);
-
-	CMProfileRef prof = NULL;
-	CMGetProfileByAVID(monitor, &prof);
-	if ( prof==NULL )
-		return rs_color_space_new_singleton("RSSrgb");
-
-	ProfileTransfer transfer = { NULL, 0 };
-	//The following code does not work on 64bit OSX.  Disable if we are compiling there.
-#ifndef __LP64__
-	Boolean foo;
-	CMFlattenProfile(prof, 0, dt_ctl_lcms_flatten_profile, &transfer, &foo);
-	CMCloseProfile(prof);
-#endif
-	buffer = transfer.data;
-	buffer_size = transfer.len;
-
-#elif defined G_OS_WIN32
-	(void)widget;
-	HDC hdc = GetDC(NULL);
-	if (hdc == NULL)
-		return rs_color_space_new_singleton("RSSrgb");
-
-	DWORD len = 0;
-	GetICMProfile (hdc, &len, NULL);
-	gchar *path = g_new (gchar, len);
-
-	if (GetICMProfile(hdc, &len, path))
-	{
-		gsize size;
-		g_file_get_contents(path, (gchar**)&buffer, &size, NULL);
-		*buffer_size = size;
-	}
-	g_free(path);
-	ReleaseDC(NULL, hdc);
-#endif
 
 	if (NULL == buffer || 0 == buffer_size)
 		return rs_color_space_new_singleton("RSSrgb");

--- a/src/gtk-helper.h
+++ b/src/gtk-helper.h
@@ -17,9 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#ifndef WIN32
 #include <gconf/gconf-client.h>
-#endif
 
 typedef struct _RS_CONFBOX RS_CONFBOX;
 
@@ -83,9 +81,9 @@ extern GtkWidget *gui_button_new_from_stock_with_label(const gchar *stock_id, co
 extern GtkWidget *gui_label_new_with_mouseover(const gchar *normal_text, const gchar *hover_text);
 
 extern void gui_box_toggle_callback(GtkExpander *expander, gchar *key);
-#ifndef WIN32
+
 extern void gui_box_notify(GConfClient *client, guint cnxn_id, GConfEntry *entry, gpointer user_data);
-#endif
+
 extern GtkWidget * gui_box(const gchar *title, GtkWidget *in, gchar *key, gboolean default_expanded);
 
 extern RSColorSpace* rs_get_display_profile(GtkWidget *widget);

--- a/src/rs-actions.c
+++ b/src/rs-actions.c
@@ -1468,23 +1468,12 @@ ACTION(online_documentation)
 {
 	const gchar *link = "https://github.com/rawstudio/rawstudio";
 
-#ifdef WIN32
-#warning This is untested
-	gchar* argv[]= {
-		getenv("ComSpec"),
-		"/c",
-		"start",
-		"uri click", /* start needs explicit title incase link has spaces or quotes */
-		(gchar*) link,
-		NULL
-	};
-#else
 	gchar *argv[]= {
 		"gnome-open", /* this feels like cheating! */
 		(gchar *) link,
 		NULL
 		};
-#endif
+
 	GError *error = NULL;
 	gint status = 0;
 	gboolean res;

--- a/src/rs-external-editor.c
+++ b/src/rs-external-editor.c
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 #include "application.h"
 #include "rs-photo.h"
-#ifndef WIN32
 #include <dbus/dbus.h>
 
 
@@ -55,14 +54,10 @@ dbus_gimp_opened (DBusConnection * connection, DBusMessage * message, void *user
 	}
 	return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 }
-#endif
 
 gboolean
 rs_external_editor_gimp(RS_PHOTO *photo, RSFilter *prior_to_resample, guint snapshot)
 {
-#ifdef WIN32
-	return FALSE;
-#else
 	RSOutput *output = NULL;
 	g_assert(RS_IS_PHOTO(photo));
 
@@ -168,9 +163,8 @@ rs_external_editor_gimp(RS_PHOTO *photo, RSFilter *prior_to_resample, guint snap
 	}
 
 	return TRUE;
-#endif
 }
-#ifndef WIN32
+
 static gboolean
 rs_has_gimp(gint major, gint minor, gint micro) {
 	FILE *fp;
@@ -234,4 +228,4 @@ rs_has_gimp(gint major, gint minor, gint micro) {
 
 	return retval;
 }
-#endif
+

--- a/src/rs-store.c
+++ b/src/rs-store.c
@@ -38,10 +38,6 @@
 #include "rs-photo.h"
 #include "rs-actions.h"
 
-#ifdef WIN32
-#undef near
-#endif
-
 /* How many different icon views do we have (tabs) */
 #define NUM_VIEWS 6
 

--- a/src/rs-toolbox.c
+++ b/src/rs-toolbox.c
@@ -20,9 +20,7 @@
 #include <rawstudio.h>
 #include <gtk/gtk.h>
 #include <config.h>
-#ifndef WIN32
 #include <gconf/gconf-client.h>
-#endif
 #include "gettext.h"
 #include "rs-toolbox.h"
 #include "gtk-interface.h"
@@ -98,11 +96,8 @@ struct _RSToolbox {
 	GtkWidget *histogram;
 	rs_profile_camera last_camera;
 
- #ifndef WIN32
 	guint histogram_connection; /* Got GConf notification */
-
 	GConfClient *gconf;
-#endif
 
 	gboolean mute_from_sliders;
 	gboolean mute_from_photo;
@@ -119,9 +114,7 @@ static guint signals[LAST_SIGNAL] = { 0 };
 static void dcp_profile_selected(RSProfileSelector *selector, RSDcpFile *dcp, RSToolbox *toolbox);
 static void icc_profile_selected(RSProfileSelector *selector, RSIccProfile *icc, RSToolbox *toolbox);
 static void add_profile_selected(RSProfileSelector *selector, RSToolbox *toolbox);
-#ifndef WIN32
 static void conf_histogram_height_changed(GConfClient *client, guint cnxn_id, GConfEntry *entry, gpointer user_data);
-#endif
 static void notebook_switch_page(GtkNotebook *notebook, gpointer page, guint page_num, RSToolbox *toolbox);
 static void basic_range_value_changed(GtkRange *range, gpointer user_data);
 static gboolean basic_range_reset(GtkWidget *widget, GdkEventButton *event, gpointer user_data);
@@ -142,11 +135,8 @@ rs_toolbox_finalize (GObject *object)
 {
 	RSToolbox *toolbox = RS_TOOLBOX(object);
 
-#ifndef WIN32
 	gconf_client_notify_remove(toolbox->gconf, toolbox->histogram_connection);
-
 	g_object_unref(toolbox->gconf);
-#endif
 
 	g_free(toolbox->last_camera.make);
 	g_free(toolbox->last_camera.model);
@@ -199,10 +189,8 @@ rs_toolbox_init (RSToolbox *self)
 	gtk_scrolled_window_set_hadjustment(scrolled_window, NULL);
 	gtk_scrolled_window_set_vadjustment(scrolled_window, NULL);
 
-#ifndef WIN32
 	/* Get a GConfClient */
 	self->gconf = gconf_client_get_default();
-#endif
 
 	/* Snapshot labels */
 	label[0] = gtk_label_new(_(" A "));
@@ -230,9 +218,7 @@ rs_toolbox_init (RSToolbox *self)
 	gtk_box_pack_start(self->toolbox, gui_box(_("Histogram"), self->histogram, "show_histogram", TRUE), FALSE, FALSE, 0);
 
 	/* Watch out for gconf-changes */
-#ifndef WIN32
 	self->histogram_connection = gconf_client_notify_add(self->gconf, "/apps/" PACKAGE "/histogram_height", conf_histogram_height_changed, self, NULL, NULL);
-#endif
 
 	/* Pack everything nice with scrollers */
 	viewport = gtk_viewport_new (gtk_scrolled_window_get_hadjustment (scrolled_window),
@@ -267,7 +253,6 @@ add_profile_selected(RSProfileSelector *selector, RSToolbox *toolbox)
 	rs_core_action_group_activate("AddProfile");
 }
 
-#ifndef WIN32
 static void
 conf_histogram_height_changed(GConfClient *client, guint cnxn_id, GConfEntry *entry, gpointer user_data)
 {
@@ -280,7 +265,6 @@ conf_histogram_height_changed(GConfClient *client, guint cnxn_id, GConfEntry *en
 		gtk_widget_set_size_request(toolbox->histogram, 64, height);
 	}
 }
-#endif
 
 static void
 notebook_switch_page(GtkNotebook *notebook, gpointer page, guint page_num, RSToolbox *toolbox)


### PR DESCRIPTION
This PR will - as the title suggests - remove support for Windows and macOS. This should make testing and maintaining Rawstudio much easier.

The support was never advertised as far as I know, and we should be able to silently drop support.