### PR TITLE
Restore installation of advanced DCP profiles

### DIFF
--- a/profiles/Makefile.am
+++ b/profiles/Makefile.am
@@ -3,6 +3,7 @@ rawstudiodir = $(datadir)/rawstudio/profiles
 RECIPE_FILES := $(wildcard recipes/*.dcpr)
 SIMPLE_SOURCE_FILES := $(wildcard simple-src/*.xml)
 DCP_FILES := $(notdir $(SIMPLE_SOURCE_FILES:.xml=.dcp))
+DCP_FILES += $(wildcard *_Rawstudio_Advanced_Profile.dcp)
 
 %.dcp: simple-src/%.xml write-dcp
 	./write-dcp "$<" "$@"


### PR DESCRIPTION
Broken in e9cdb92.

Fixes #27.