### PR TITLE
rs-exif.cc: add exiv2 headers

### DIFF
--- a/librawstudio/rs-exif.cc
+++ b/librawstudio/rs-exif.cc
@@ -19,6 +19,9 @@
 
 #include <iostream>
 #include <iomanip>
+#include <exiv2/image.hpp>
+#include <exiv2/exif.hpp>
+#include <exiv2/error.hpp>
 #include <exiv2/exiv2.hpp>
 #include "rs-exif.h"
 #include <assert.h>


### PR DESCRIPTION
Addresses the error on MacOS:
```
:info:build rs-exif.cc: In function 'RS_EXIF_DATA* rs_exif_load_from_file(const gchar*)':
:info:build rs-exif.cc:139:23: error: 'AnyError' in namespace 'Exiv2' does not name a type
:info:build   139 |         catch (Exiv2::AnyError& e)
:info:build       |                       ^~~~~~~~
:info:build rs-exif.cc: In function 'RS_EXIF_DATA* rs_exif_load_from_rawfile(RAWFILE*)':
:info:build rs-exif.cc:164:23: error: 'AnyError' in namespace 'Exiv2' does not name a type
:info:build   164 |         catch (Exiv2::AnyError& e)
:info:build       |                       ^~~~~~~~
:info:build rs-exif.cc: In function 'void rs_exif_add_to_file(RS_EXIF_DATA*, Exiv2::IptcData&, const gchar*, RSExifFileType)':
:info:build rs-exif.cc:197:23: error: 'AnyError' in namespace 'Exiv2' does not name a type
:info:build   197 |         catch (Exiv2::AnyError& e)
:info:build       |                       ^~~~~~~~
:info:build rs-exif.cc: In function 'gboolean rs_exif_copy(const gchar*, const gchar*, const gchar*, RSExifFileType)':
:info:build rs-exif.cc:335:28: error: 'versionNumber' is not a member of 'Exiv2'
:info:build   335 |                 if (Exiv2::versionNumber() < 0x1400)
:info:build       |                            ^~~~~~~~~~~~~
```

10.6.8 Rosetta, `gcc12` @12.1.0, `exiv2` @0.27.5.