### PR TITLE
inlines must be static in dcp.c

### DIFF
--- a/plugins/dcp/dcp.c
+++ b/plugins/dcp/dcp.c
@@ -693,7 +693,7 @@ neutral_to_xy(RSDcp *dcp, const RS_VECTOR3 *neutral)
 	return last;
 }
 
-inline void
+static inline void
 RGBtoHSV(gfloat r, gfloat g, gfloat b, gfloat *h, gfloat *s, gfloat *v)
 {
 	*v = MAX(r, MAX (g, b));
@@ -723,7 +723,7 @@ RGBtoHSV(gfloat r, gfloat g, gfloat b, gfloat *h, gfloat *s, gfloat *v)
 	}
 }
 
-inline gfloat
+static inline gfloat
 exposure_ramp (RSDcp *dcp, gfloat x)
 {
 	if (x <= dcp->exposure_black - dcp->exposure_radius)
@@ -738,7 +738,7 @@ exposure_ramp (RSDcp *dcp, gfloat x)
 }
 
 
-inline void
+static inline void
 HSVtoRGB(gfloat h, gfloat s, gfloat v, gfloat *r, gfloat *g, gfloat *b)
 {
 	if (s > 0.0f)


### PR DESCRIPTION
Non-static inline functions will be removed from the translation unit if the compiler can't inline them. Which results in an error when loading the "plugins/dcp.so" because it is missing a required symbol.